### PR TITLE
🐛 fix: color issue with drun option

### DIFF
--- a/style.css
+++ b/style.css
@@ -34,6 +34,18 @@ border: none;
 color: #f8f8f2;
 } 
 
+#entry.activatable #text {
+color: #282a36;
+}
+
+#entry > * {
+color: #f8f8f2;
+}
+
 #entry:selected {
 background-color: #44475a;
+}
+
+#entry:selected #text {
+font-weight: bold;
 }


### PR DESCRIPTION
Hi, 
A little fix for when you use the `show=drun` option.
And adding bold to the active text entry.

![screenshot-2023-06-09-02-46-57](https://github.com/dracula/wofi/assets/15379333/576b6a02-0a09-47da-aa99-9cf8fffaa853)
![screenshot-2023-06-09-02-45-55](https://github.com/dracula/wofi/assets/15379333/34d4f7d0-ca80-4fdd-83a9-103c10262c53)
